### PR TITLE
feat: crud de planos + atualização de permissões

### DIFF
--- a/src/backend/src/api/advantage/content-types/advantage/schema.json
+++ b/src/backend/src/api/advantage/content-types/advantage/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "advantages",
+  "info": {
+    "singularName": "advantage",
+    "pluralName": "advantages",
+    "displayName": "Advantage"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "plans_id": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::plan.plan",
+      "mappedBy": "advantage_id"
+    }
+  }
+}

--- a/src/backend/src/api/advantage/controllers/advantage.js
+++ b/src/backend/src/api/advantage/controllers/advantage.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * advantage controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::advantage.advantage');

--- a/src/backend/src/api/advantage/routes/advantage.js
+++ b/src/backend/src/api/advantage/routes/advantage.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * advantage router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::advantage.advantage');

--- a/src/backend/src/api/advantage/services/advantage.js
+++ b/src/backend/src/api/advantage/services/advantage.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * advantage service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::advantage.advantage');

--- a/src/backend/src/api/faq/content-types/faq/schema.json
+++ b/src/backend/src/api/faq/content-types/faq/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "faqs",
+  "info": {
+    "singularName": "faq",
+    "pluralName": "faqs",
+    "displayName": "Faq"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "question": {
+      "type": "string"
+    },
+    "answer": {
+      "type": "string"
+    },
+    "plans_id": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::plan.plan",
+      "mappedBy": "faq_id"
+    }
+  }
+}

--- a/src/backend/src/api/faq/controllers/faq.js
+++ b/src/backend/src/api/faq/controllers/faq.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * faq controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::faq.faq');

--- a/src/backend/src/api/faq/routes/faq.js
+++ b/src/backend/src/api/faq/routes/faq.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * faq router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::faq.faq');

--- a/src/backend/src/api/faq/services/faq.js
+++ b/src/backend/src/api/faq/services/faq.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * faq service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::faq.faq');

--- a/src/backend/src/api/payment/content-types/payment/schema.json
+++ b/src/backend/src/api/payment/content-types/payment/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "payments",
+  "info": {
+    "singularName": "payment",
+    "pluralName": "payments",
+    "displayName": "Payment"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "plans_id": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::plan.plan",
+      "mappedBy": "payment_id"
+    }
+  }
+}

--- a/src/backend/src/api/payment/controllers/payment.js
+++ b/src/backend/src/api/payment/controllers/payment.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * payment controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::payment.payment');

--- a/src/backend/src/api/payment/routes/payment.js
+++ b/src/backend/src/api/payment/routes/payment.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * payment router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::payment.payment');

--- a/src/backend/src/api/payment/services/payment.js
+++ b/src/backend/src/api/payment/services/payment.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * payment service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::payment.payment');

--- a/src/backend/src/api/plan/content-types/plan/schema.json
+++ b/src/backend/src/api/plan/content-types/plan/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "plans",
+  "info": {
+    "singularName": "plan",
+    "pluralName": "plans",
+    "displayName": "Plan",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string"
+    },
+    "price": {
+      "type": "decimal"
+    },
+    "advantage_id": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::advantage.advantage",
+      "inversedBy": "plans_id"
+    },
+    "payment_id": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::payment.payment",
+      "inversedBy": "plans_id"
+    },
+    "faq_id": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::faq.faq",
+      "inversedBy": "plans_id"
+    }
+  }
+}

--- a/src/backend/src/api/plan/controllers/plan.js
+++ b/src/backend/src/api/plan/controllers/plan.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * plan controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::plan.plan');

--- a/src/backend/src/api/plan/routes/plan.js
+++ b/src/backend/src/api/plan/routes/plan.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * plan router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::plan.plan');

--- a/src/backend/src/api/plan/services/plan.js
+++ b/src/backend/src/api/plan/services/plan.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * plan service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::plan.plan');

--- a/src/backend/types/generated/contentTypes.d.ts
+++ b/src/backend/types/generated/contentTypes.d.ts
@@ -833,6 +833,42 @@ export interface ApiAboutUsAboutUs extends Schema.CollectionType {
   };
 }
 
+export interface ApiAdvantageAdvantage extends Schema.CollectionType {
+  collectionName: 'advantages';
+  info: {
+    singularName: 'advantage';
+    pluralName: 'advantages';
+    displayName: 'Advantage';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    description: Attribute.String;
+    plans_id: Attribute.Relation<
+      'api::advantage.advantage',
+      'oneToMany',
+      'api::plan.plan'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::advantage.advantage',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::advantage.advantage',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiBannerBanner extends Schema.CollectionType {
   collectionName: 'banners';
   info: {
@@ -1224,6 +1260,30 @@ export interface ApiEventRegistrarionCardEventRegistrarionCard
   };
 }
 
+export interface ApiFaqFaq extends Schema.CollectionType {
+  collectionName: 'faqs';
+  info: {
+    singularName: 'faq';
+    pluralName: 'faqs';
+    displayName: 'Faq';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    question: Attribute.String;
+    answer: Attribute.String;
+    plans_id: Attribute.Relation<'api::faq.faq', 'oneToMany', 'api::plan.plan'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::faq.faq', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::faq.faq', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
 export interface ApiMemberMember extends Schema.CollectionType {
   collectionName: 'members';
   info: {
@@ -1310,6 +1370,42 @@ export interface ApiPartnerPartner extends Schema.CollectionType {
   };
 }
 
+export interface ApiPaymentPayment extends Schema.CollectionType {
+  collectionName: 'payments';
+  info: {
+    singularName: 'payment';
+    pluralName: 'payments';
+    displayName: 'Payment';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    description: Attribute.String;
+    plans_id: Attribute.Relation<
+      'api::payment.payment',
+      'oneToMany',
+      'api::plan.plan'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::payment.payment',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::payment.payment',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiPhotoPhoto extends Schema.CollectionType {
   collectionName: 'photos';
   info: {
@@ -1375,6 +1471,41 @@ export interface ApiPhotoProductPhotoProduct extends Schema.CollectionType {
       'oneToOne',
       'admin::user'
     > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPlanPlan extends Schema.CollectionType {
+  collectionName: 'plans';
+  info: {
+    singularName: 'plan';
+    pluralName: 'plans';
+    displayName: 'Plan';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    name: Attribute.String;
+    price: Attribute.Decimal;
+    advantage_id: Attribute.Relation<
+      'api::plan.plan',
+      'manyToOne',
+      'api::advantage.advantage'
+    >;
+    payment_id: Attribute.Relation<
+      'api::plan.plan',
+      'manyToOne',
+      'api::payment.payment'
+    >;
+    faq_id: Attribute.Relation<'api::plan.plan', 'manyToOne', 'api::faq.faq'>;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::plan.plan', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::plan.plan', 'oneToOne', 'admin::user'> &
       Attribute.Private;
   };
 }
@@ -1684,6 +1815,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'plugin::i18n.locale': PluginI18NLocale;
       'api::about-us.about-us': ApiAboutUsAboutUs;
+      'api::advantage.advantage': ApiAdvantageAdvantage;
       'api::banner.banner': ApiBannerBanner;
       'api::board.board': ApiBoardBoard;
       'api::category.category': ApiCategoryCategory;
@@ -1693,10 +1825,13 @@ declare module '@strapi/types' {
       'api::event.event': ApiEventEvent;
       'api::event-form.event-form': ApiEventFormEventForm;
       'api::event-registrarion-card.event-registrarion-card': ApiEventRegistrarionCardEventRegistrarionCard;
+      'api::faq.faq': ApiFaqFaq;
       'api::member.member': ApiMemberMember;
       'api::partner.partner': ApiPartnerPartner;
+      'api::payment.payment': ApiPaymentPayment;
       'api::photo.photo': ApiPhotoPhoto;
       'api::photo-product.photo-product': ApiPhotoProductPhotoProduct;
+      'api::plan.plan': ApiPlanPlan;
       'api::planning.planning': ApiPlanningPlanning;
       'api::product.product': ApiProductProduct;
       'api::purpose.purpose': ApiPurposePurpose;


### PR DESCRIPTION
Foi criado:
- Tabela de planos: nome, preço, id de vantagem, id pagamentos, id de faq;
- Tabela de vantagem: nome e descrição;
- Tabela de pagamentos: nome e descrição;
- Tabela de Faq: pergunta e resposta.

Atualizações:
- Acessos ao crud de planos para diretorias especificas: Esportes e presidência.